### PR TITLE
Multiple code improvements - squid:LowerCaseLongSuffixCheck, squid:S1488, squid:S1854

### DIFF
--- a/cxf-rest-client/src/main/java/org/apache/camel/example/cxfrs/Main.java
+++ b/cxf-rest-client/src/main/java/org/apache/camel/example/cxfrs/Main.java
@@ -12,6 +12,6 @@ public class Main{
 	public static void main(String[] args) throws Exception {
 		
 		new ClassPathXmlApplicationContext("classpath:camel-context.xml");
-		Thread.currentThread().sleep(1000000l);
+		Thread.currentThread().sleep(1000000L);
 	}
 }

--- a/cxf-rest-service/src/main/java/org/apache/camel/example/cxfrs/impl/CountryServiceImpl.java
+++ b/cxf-rest-service/src/main/java/org/apache/camel/example/cxfrs/impl/CountryServiceImpl.java
@@ -34,14 +34,14 @@ public class CountryServiceImpl implements CountryService {
 
 	public Response getCountry(String countryCode) {
 
-		Response response = null;
+		Response response;
 		Map<String, Country>  countries =  new HashMap<String, Country>();
 		CountryResponse countryResponse = new CountryResponse();
 		countryResponse.setCountries(countries);
 
 		if(StringUtils.isEmpty(countryCode)){
 			countryResponse.setMessage("Country Code Not provided!") ;
-			response = Response.ok(countryResponse).status(Status.BAD_REQUEST).build();
+			Response.ok(countryResponse).status(Status.BAD_REQUEST).build();
 		}
 
 		Country country = countryMap.get(countryCode.toUpperCase());
@@ -63,8 +63,6 @@ public class CountryServiceImpl implements CountryService {
 		CountryResponse countryResponse = new CountryResponse();
 		countryResponse.setCountries(countryMap);
 		countryResponse.setMessage("ok");
-		Response response = Response.ok(countryResponse).status(Status.OK).build();
-
-		return response;
+		return Response.ok(countryResponse).status(Status.OK).build();
 	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:LowerCaseLongSuffixCheck - Long suffix "L" should be upper case.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S1854 - Dead stores should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:LowerCaseLongSuffixCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1854
Please let me know if you have any questions.
George Kankava